### PR TITLE
Update torrentdownloader.h

### DIFF
--- a/torrentdownloader.h
+++ b/torrentdownloader.h
@@ -11,7 +11,7 @@ class TorrentDownloader : public QObject
     Q_OBJECT
     QTimer progressTimer;
     
-    std::unique_ptr<TorrentDownloaderPrivate, std::function<void(TorrentDownloaderPrivate*)>> p;
+    std::unique_ptr<TorrentDownloaderPrivate, std::is_function<void(TorrentDownloaderPrivate*)>> p;
 public:
     TorrentDownloader();
     


### PR DESCRIPTION
UTLauncher was failing to compile and complaining about line 14:
"../torrentdownloader.h:14:52: error: ‘function’ is not a member of ‘std’"
Suggested alternative was "is_function".
Compiled after I followed the suggestion.